### PR TITLE
[dynamicviz] optimize bootstrap concatenation

### DIFF
--- a/dynamicviz/boot.py
+++ b/dynamicviz/boot.py
@@ -286,6 +286,7 @@ def generate(
 
     # add bootstraps
     start_time = time.time()
+    dfs = []
     for i in range(len(bootstrap_embedding_list)):
 
         new_df = pd.DataFrame()  # new df to merge onto original df
@@ -314,8 +315,10 @@ def generate(
             for col in Y.columns:
                 new_df[col] = Y[col].values[boot_idxs]
 
-        # merge to original dataframe
-        output = pd.concat([output, new_df], axis=0)
+        dfs.append(new_df)
+
+    if dfs:
+        output = pd.concat([output] + dfs, axis=0)
 
     align_time = time.time() - start_time
     rt_dict["alignment_DR"] = align_time

--- a/tests/test_distance_equiv.py
+++ b/tests/test_distance_equiv.py
@@ -6,7 +6,7 @@ import pandas as pd
 from sklearn.datasets import make_s_curve
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
-from dynamicviz import boot, score
+from dynamicviz.dynamicviz import boot, score
 
 
 # Baseline implementations copied from the previous version of score.py

--- a/tests/test_generate_equiv.py
+++ b/tests/test_generate_equiv.py
@@ -1,0 +1,96 @@
+import os
+import sys
+
+import numpy as np
+import pandas as pd
+from sklearn.datasets import make_s_curve
+from scipy.spatial.transform import Rotation
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from dynamicviz.dynamicviz import boot
+
+
+def generate_reference(
+    X,
+    method,
+    Y=None,
+    B=0,
+    sigma_noise=None,
+    no_bootstrap=False,
+    random_seed=None,
+    num_jobs=None,
+    use_n_pcs=False,
+    subsample=False,
+    **kwargs,
+):
+    """Replicates the original generate behavior using sequential concatenation."""
+    output = pd.DataFrame()
+
+    original_embedding = boot.dimensionality_reduction(X, method, **kwargs)
+    points0 = np.hstack(
+        (original_embedding, np.zeros((original_embedding.shape[0], 1)))
+    )
+
+    output["x1"] = points0[:, 0] - np.mean(points0[:, 0])
+    output["x2"] = points0[:, 1] - np.mean(points0[:, 1])
+    output["original_index"] = np.arange(len(points0[:, 0]))
+    output["bootstrap_number"] = -1
+
+    if isinstance(Y, pd.DataFrame):
+        for col in Y.columns:
+            output[col] = Y[col].values
+
+    if B > 0:
+        bootstrap_embedding_list, bootstrap_indices_list = boot.bootstrap(
+            X,
+            method,
+            B,
+            sigma_noise,
+            no_bootstrap,
+            random_seed,
+            num_jobs,
+            use_n_pcs,
+            subsample,
+            **kwargs,
+        )
+    else:
+        bootstrap_embedding_list, bootstrap_indices_list = [], []
+
+    for i in range(len(bootstrap_embedding_list)):
+        new_df = pd.DataFrame()
+        points = bootstrap_embedding_list[i]
+        points = np.hstack((points, np.zeros((points.shape[0], 1))))
+        boot_idxs = bootstrap_indices_list[i]
+
+        ref_points = points0[boot_idxs, :]
+        points[:, 0] = points[:, 0] - np.mean(points[:, 0])
+        points[:, 1] = points[:, 1] - np.mean(points[:, 1])
+        r = Rotation.align_vectors(ref_points, points)[0]
+        rpoints = r.apply(points)
+
+        new_df["x1"] = rpoints[:, 0]
+        new_df["x2"] = rpoints[:, 1]
+        new_df["original_index"] = boot_idxs
+        new_df["bootstrap_number"] = i
+
+        if isinstance(Y, pd.DataFrame):
+            for col in Y.columns:
+                new_df[col] = Y[col].values[boot_idxs]
+
+        output = pd.concat([output, new_df], axis=0)
+
+    return output
+
+
+def test_generate_output_equivalence():
+    X, y = make_s_curve(30, random_state=0)
+    y_df = pd.DataFrame(y, columns=["label"])
+
+    ref = generate_reference(X, "pca", Y=y_df, B=2, random_seed=0, random_state=0)
+    new = boot.generate(
+        X, Y=y_df, method="pca", B=2, save=False, random_seed=0, random_state=0
+    )
+
+    pd.testing.assert_frame_equal(
+        ref.reset_index(drop=True), new.reset_index(drop=True)
+    )

--- a/tests/test_score_speed.py
+++ b/tests/test_score_speed.py
@@ -7,7 +7,7 @@ from sklearn.datasets import make_s_curve
 from sklearn.metrics import pairwise_distances
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
-from dynamicviz import boot, score
+from dynamicviz.dynamicviz import boot, score
 
 X, y = make_s_curve(200, random_state=0)
 y = pd.DataFrame(y, columns=["label"])


### PR DESCRIPTION
## Summary
- optimize aggregation of bootstrap dataframes in `boot.generate`
- ensure tests import package from correct path
- add regression test covering new dataframe construction

## Testing
- `ruff check .`
- `black . --check`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6851abe18fa88333a36dc5ca1b5cc181

## Summary by Sourcery

Optimize bootstrap concatenation, correct test imports, and add a regression test for DataFrame construction in `boot.generate`.

Bug Fixes:
- Fix test imports to reference `dynamicviz.dynamicviz` correctly.

Enhancements:
- Collect bootstrap DataFrames in a list and perform a single concatenation to improve performance.

Tests:
- Add regression test to verify `boot.generate` output matches reference sequential concatenation behavior.