### PR TITLE
[dynamicviz] Fix test imports

### DIFF
--- a/tests/test_distance_equiv.py
+++ b/tests/test_distance_equiv.py
@@ -6,7 +6,7 @@ import pandas as pd
 from sklearn.datasets import make_s_curve
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
-from dynamicviz.dynamicviz import boot, score
+from dynamicviz import boot, score
 
 
 # Baseline implementations copied from the previous version of score.py

--- a/tests/test_generate_equiv.py
+++ b/tests/test_generate_equiv.py
@@ -7,7 +7,7 @@ from sklearn.datasets import make_s_curve
 from scipy.spatial.transform import Rotation
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
-from dynamicviz.dynamicviz import boot
+from dynamicviz import boot
 
 
 def generate_reference(

--- a/tests/test_score_speed.py
+++ b/tests/test_score_speed.py
@@ -7,7 +7,7 @@ from sklearn.datasets import make_s_curve
 from sklearn.metrics import pairwise_distances
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
-from dynamicviz.dynamicviz import boot, score
+from dynamicviz import boot, score
 
 X, y = make_s_curve(200, random_state=0)
 y = pd.DataFrame(y, columns=["label"])


### PR DESCRIPTION
## Summary
- fix imports in test modules so dynamicviz package is found

## Testing
- `black . --check`
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6851c0fd6e888333aa932d5623a311c5

## Summary by Sourcery

Tests:
- Update import statements in test_generate_equiv.py, test_score_speed.py, and test_distance_equiv.py to import boot and score from the dynamicviz package root instead of dynamicviz.dynamicviz.