### PR TITLE
[dynamicviz] Fix concordance metrics and add tests

### DIFF
--- a/tests/test_concordance_equiv.py
+++ b/tests/test_concordance_equiv.py
@@ -1,0 +1,52 @@
+import os
+import sys
+
+import numpy as np
+from sklearn.datasets import make_s_curve
+from sklearn.metrics import pairwise_distances
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from dynamicviz import score, boot
+
+
+def jaccard_reference(X_orig, X_red, k):
+    dist_orig = pairwise_distances(X_orig)
+    dist_red = pairwise_distances(X_red)
+    indices_orig = np.argsort(dist_orig, axis=1)[:, 1 : k + 1]
+    indices_red = np.argsort(dist_red, axis=1)[:, 1 : k + 1]
+    result = []
+    for neigh_o, neigh_r in zip(indices_orig, indices_red):
+        inter = len(np.intersect1d(neigh_o, neigh_r))
+        union = 2 * k - inter
+        result.append(inter / union)
+    return np.array(result)
+
+
+def distortion_reference(X_orig, X_red, k):
+    dist_orig = pairwise_distances(X_orig)
+    dist_red = pairwise_distances(X_red)
+    sorted_orig = np.sort(dist_orig, axis=1)
+    sorted_red = np.sort(dist_red, axis=1)
+    orig_ratio = sorted_orig[:, k] / sorted_orig[:, 1]
+    red_ratio = sorted_red[:, k] / sorted_red[:, 1]
+    distortions = np.abs(np.log(orig_ratio / red_ratio))
+    distortions = distortions / np.max(distortions)
+    return 1 - distortions
+
+
+def test_jaccard_and_distortion_equivalence():
+    X, _ = make_s_curve(50, random_state=0)
+    data = boot.generate(
+        X, method="pca", B=1, save=False, random_seed=0, random_state=0
+    )
+    X_red = data[data["bootstrap_number"] == -1][["x1", "x2"]].values
+
+    k = 5
+    ref_jaccard = jaccard_reference(X, X_red, k)
+    ref_distortion = distortion_reference(X, X_red, k)
+
+    jaccard = score.get_jaccard(X, X_red, k)
+    distortion = score.get_distortion(X, X_red, k)
+
+    assert np.allclose(jaccard, ref_jaccard, atol=1e-8)
+    assert np.allclose(distortion, ref_distortion, atol=1e-8)


### PR DESCRIPTION
## Summary
- correct neighbor indexing in Jaccard and distortion calculations
- clarify metric docstrings and fix typos
- add reference tests for concordance metrics

## Testing
- `ruff check .`
- `pytest -q`
- `pytest --cov=dynamicviz --cov-report=term-missing -q`


------
https://chatgpt.com/codex/tasks/task_e_6851dda65c6883338adee35dd56043d4

## Summary by Sourcery

Update concordance score implementations for Jaccard and distortion by correcting neighbor indexing, refactoring to use pairwise distances, improving documentation, and adding reference tests to ensure metric correctness.

New Features:
- Add reference tests to validate Jaccard and distortion metrics against known implementations

Bug Fixes:
- Correct neighbor indexing and union computation in Jaccard coefficient calculation
- Fix normalization and indexing in distortion metric calculation

Enhancements:
- Refactor get_jaccard and get_distortion to use pairwise distance matrices for improved clarity
- Enhance docstrings for concordance metrics to clarify parameters and return values

Documentation:
- Fix typos and clarify docstrings for concordance score functions

Tests:
- Add end-to-end equivalence tests for Jaccard and distortion metrics using synthetic data