### PR TITLE
[dynamicviz] Add workflow for pytest

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -18,5 +18,6 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           pip install .
+          pip install pytest pytest-cov
       - name: Run tests
-        run: pytest -q
+        run: pytest --cov=dynamicviz --cov-report=xml --cov-report=term

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,0 +1,22 @@
+name: Run Tests
+
+on:
+  pull_request:
+  push:
+    branches: [ main, master ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install .
+      - name: Run tests
+        run: pytest -q

--- a/dynamicviz/score.py
+++ b/dynamicviz/score.py
@@ -296,7 +296,9 @@ def populate_distance_dict(neighborhood_dict, embeddings, bootstrap_indices):
 
             if pairs:
                 sub_emb = emb[[i_idx] + [p for p, _ in pairs]]
-                dists = pairwise_distances(sub_emb, n_jobs=int(0.75 * os.cpu_count()))[0, 1:]
+                dists = pairwise_distances(sub_emb, n_jobs=int(0.75 * os.cpu_count()))[
+                    0, 1:
+                ]
                 for (pos, key2), dist in zip(pairs, dists):
                     if pos == i_idx:
                         dist = 0.0


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run pytest
- format `score.py` with `black`

## Testing
- `black . --check`
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68531e2eedf48333bd3b7e95dbef957a

## Summary by Sourcery

Add a CI workflow to run pytest via GitHub Actions and apply Black formatting to score.py

Enhancements:
- Reformat score.py using Black for consistent code style

CI:
- Add a GitHub Actions workflow to run pytest on pull requests and pushes to main/master