### PR TITLE
[dynamicviz] cap alpha heuristic

### DIFF
--- a/dynamicviz/viz.py
+++ b/dynamicviz/viz.py
@@ -416,9 +416,10 @@ def stacked(
         if vmax is None:
             vmax = np.max(df[label])
 
-    # automatically set alpha based on heuristic
+    # automatically set alpha based on heuristic and cap at 1.0 for small datasets
     if alpha is None:
         alpha = 0.2 / (df.shape[0] / 1000)
+        alpha = min(alpha, 1.0)
 
     fig = plt.figure(figsize=(width, height))
 


### PR DESCRIPTION
## Summary
- limit automatic alpha heuristic so opacity never exceeds 1

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853295697d08333b6ac92fc5f54707d

## Summary by Sourcery

Enhancements:
- Limit the automatically computed alpha value to a maximum of 1.0.